### PR TITLE
Issue 39 remove gemini

### DIFF
--- a/islandora_riprap.module
+++ b/islandora_riprap.module
@@ -172,7 +172,7 @@ function islandora_riprap_islandora_premis_turtle_alter($nid, &$turtle) {
         $binary_resource_url = $islandora_riprap_utils->getLocalUrl($medium->id());
       }
       else {
-        $binary_resource_url = $islandora_riprap_utils->getFedoraUrl($file->uuid());
+        $binary_resource_url = $islandora_riprap_utils->getFedoraUrl($medium->id());
       }
 
       // Create the graph from existing Turtle.

--- a/src/Controller/IslandoraRiprapMediaEventsController.php
+++ b/src/Controller/IslandoraRiprapMediaEventsController.php
@@ -39,7 +39,7 @@ class IslandoraRiprapMediaEventsController extends ControllerBase {
       $binary_resource_url = $utils->getLocalUrl($mid);
     }
     else {
-      $binary_resource_url = $utils->getFedoraUrl($binary_resource_uuid);
+      $binary_resource_url = $utils->getFedoraUrl($mid);
     }
 
     $riprap_output = $riprap->getEvents(['output_format' => 'json', 'resource_id' => $binary_resource_url]);

--- a/src/Plugin/Form/IslandoraRiprapSettingsForm.php
+++ b/src/Plugin/Form/IslandoraRiprapSettingsForm.php
@@ -100,12 +100,6 @@ class IslandoraRiprapSettingsForm extends ConfigFormBase {
       '#title' => $this->t('Number of events to show in each Media\'s "Details" report. Leave empty to show all.'),
       '#default_value' => $config->get('number_of_events'),
     ];
-    $form['gemini_rest_endpoint'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Gemini microservice REST endpoint'),
-      '#description' => $this->t('Do not include the trailing /.'),
-      '#default_value' => $config->get('gemini_rest_endpoint'),
-    ];
     $form['use_drupal_urls'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Use Drupal URLs for media instead of Fedora URLs. Check this box only if you are not using Fedora.'),
@@ -215,7 +209,6 @@ class IslandoraRiprapSettingsForm extends ConfigFormBase {
       ->set('riprap_local_settings_file', rtrim($form_state->getValue('riprap_local_settings_file'), '/'))
       ->set('execute_riprap_in_cron', $form_state->getValue('execute_riprap_in_cron'))
       ->set('number_of_events', $form_state->getValue('number_of_events'))
-      ->set('gemini_rest_endpoint', rtrim($form_state->getValue('gemini_rest_endpoint'), '/'))
       ->set('use_drupal_urls', $form_state->getValue('use_drupal_urls'))
       ->set('log_riprap_warnings', $form_state->getValue('log_riprap_warnings'))
       ->set('use_sample_failed_fixity_events', $form_state->getValue('use_sample_failed_fixity_events'))
@@ -248,22 +241,14 @@ fixity_algorithm: sha256
 # Plugins #
 ###########
 
-plugins.fetchresourcelist: ['PluginFetchResourceListFromDrupal']
+# Use this plugin if you want to use the 'Riprap resource (media) list' View provided by Islandora Riprap.
+plugins.fetchresourcelist: ['PluginFetchResourceListFromDrupalView']
 drupal_baseurl: '$base_url'
-jsonapi_authorization_headers: ['Authorization: Basic YWRtaW46aXNsYW5kb3Jh']
-drupal_media_auth: ['{$values['user_name']}', '{$values['user_pass']}']
-drupal_content_types: ['{$values['fixity_content_type']}']
-drupal_media_tags: ['/taxonomy/term/{$values['fixity_terms']}']
-use_fedora_urls: true
-gemini_endpoint: '{$values['gemini_rest_endpoint']}'
-gemini_auth_header: 'Bearer islandora'
-# Can be a maximum of 50.
-jsonapi_page_size: 50
-# The number of resources to check in one Riprap run; if absent, will use
-# value defined in jsonapi_page_size. Must be a multiple of number specified
-# in jsonapi_page_size.
-max_resources: 1000
-jsonapi_pager_data_file_path: '/var/www/html/riprap/var/fetchresourcelist.from.drupal.pager.txt'
+drupal_user: {$values['user_name']}
+drupal_password: {$values['user_pass']}
+fedora_baseurl: 'http://127.0.0.1:8080/fcrepo/rest'
+# Absolute or relative to the Riprap application directory.
+views_pager_data_file_path: 'var/fetchresourcelist.from.drupal.pager.txt'
 
 plugins.fetchdigest: PluginFetchDigestFromFedoraAPI
 fedoraapi_method: HEAD
@@ -274,6 +259,7 @@ plugins.persist: PluginPersistToDatabase
 plugins.postcheck: ['PluginPostCheckCopyFailures']
 # Absolute or relative to the Riprap application directory.
 failures_log_path: '/tmp/riprap_failed_events.log'
+
 EOF;
     return $riprap_config;
   }

--- a/src/Plugin/views/field/RiprapResults.php
+++ b/src/Plugin/views/field/RiprapResults.php
@@ -41,7 +41,7 @@ class RiprapResults extends FieldPluginBase {
       $binary_resource_url = $utils->getLocalUrl($mid);
     }
     else {
-      $binary_resource_url = $utils->getFedoraUrl($binary_resource_uuid);
+      $binary_resource_url = $utils->getFedoraUrl($mid);
     }
 
     $num_events = $config->get('number_of_events') ?: 10;

--- a/src/Plugin/views/field/RiprapResults.php
+++ b/src/Plugin/views/field/RiprapResults.php
@@ -35,13 +35,20 @@ class RiprapResults extends FieldPluginBase {
 
     $media = $value->_entity;
     $mid = $media->id();
-    $binary_resource_uuid = $utils->getFileUuid($mid);
 
     if ($this->use_drupal_urls) {
       $binary_resource_url = $utils->getLocalUrl($mid);
     }
     else {
       $binary_resource_url = $utils->getFedoraUrl($mid);
+      if (!$binary_resource_url) {
+        return [
+          '#theme' => 'islandora_riprap_summary',
+          '#content' => 'Not in Fedora',
+          '#outcome' => NULL,
+          '#mid' => NULL,
+        ];
+      }
     }
 
     $num_events = $config->get('number_of_events') ?: 10;

--- a/src/Riprap/Riprap.php
+++ b/src/Riprap/Riprap.php
@@ -129,6 +129,7 @@ class Riprap {
       return TRUE;
     }
     else {
+      \Drupal::logger('islandora_riprap')->error($process->getErrorOutput());
       return FALSE;
     }
   }


### PR DESCRIPTION
# Github issue

https://github.com/mjordan/islandora_riprap/issues/39

# What's new

Removes direct query to Gemini to get a file's Fedora URI, and replaces that query with the 'islandora.entity_mapper' service.

# How to test

This change should be invisible, it basically makes Islandora Riprap's code consistent with Islandora's. The desired results of a smoke test are that Islandora Riprap continues to work as before the changes.

1. Install a fresh Islandora Playbook (or your preferred flavor of test enviro). Populate with some nodes and media.
2. Install a fresh [Riprap](https://github.com/mjordan/riprap), which also contains some updates to match changes in this module. "Local" mode is OK (i.e. Riprap installed on the Drupal server, not as a remote HTTP microservice).
2. Install this module and check out the "issue-39-remove-gemini" branch.
3. Don't forget to add the fixity audit summaries to the Manage Media View (see "Enabling the Fixity Auditing summaries in each object's Media tab" section of this module's README).
3. Configure the module at `/admin/config/islandora_riprap/settings`. Regardless of whether you're using local or remote mode, use the "Use the "sample_islandora_config.yml" configuration file (adjust as needed).

Run Ripap 4-5 times times, either via its CLI or using Drupal's cron. You should see entries in Riprap's database for them, and also fixity auditing summaries in the Manage Media View. If you do, the smoke test worked.


