### PR TITLE
Allow use of remote video media

### DIFF
--- a/src/Riprap/IslandoraRiprapUtils.php
+++ b/src/Riprap/IslandoraRiprapUtils.php
@@ -72,7 +72,6 @@ class IslandoraRiprapUtils {
     $media = Media::load($mid);
     $media_source_service = \Drupal::service('islandora.media_source_service');
     $source_file = (is_object($media)) ? $media_source_service->getSourceFile($media) : NULL;
-//    $uri = $source_file->getFileUri();
     if ($source_file) {
       $uri = $source_file->getFileUri();
     }

--- a/src/Riprap/IslandoraRiprapUtils.php
+++ b/src/Riprap/IslandoraRiprapUtils.php
@@ -70,8 +70,11 @@ class IslandoraRiprapUtils {
    */
   public function getFedoraUrl($mid) {
     $media = Media::load($mid);
+    if ($media->bundle() == 'remote_video') {
+      return False
+    }
     $media_source_service = \Drupal::service('islandora.media_source_service');
-    $source_file = (is_object($media) && $media->bundle() <> 'remote_video') ? $media_source_service->getSourceFile($media) : NULL;
+    $source_file = $media_source_service->getSourceFile($media);
     if ($source_file) {
       $uri = $source_file->getFileUri();
     }

--- a/src/Riprap/IslandoraRiprapUtils.php
+++ b/src/Riprap/IslandoraRiprapUtils.php
@@ -71,8 +71,14 @@ class IslandoraRiprapUtils {
   public function getFedoraUrl($mid) {
     $media = Media::load($mid);
     $media_source_service = \Drupal::service('islandora.media_source_service');
-    $source_file = $media_source_service->getSourceFile($media);
-    $uri = $source_file->getFileUri();
+    $source_file = (is_object($media)) ? $media_source_service->getSourceFile($media) : NULL;
+//    $uri = $source_file->getFileUri();
+    if ($source_file) {
+      $uri = $source_file->getFileUri();
+    }
+    else {
+      return false;
+    }
     $scheme = \Drupal::service('stream_wrapper_manager')->getScheme($uri);
     $mapper = \Drupal::service('islandora.entity_mapper');
 

--- a/src/Riprap/IslandoraRiprapUtils.php
+++ b/src/Riprap/IslandoraRiprapUtils.php
@@ -71,7 +71,7 @@ class IslandoraRiprapUtils {
   public function getFedoraUrl($mid) {
     $media = Media::load($mid);
     $media_source_service = \Drupal::service('islandora.media_source_service');
-    $source_file = (is_object($media)) ? $media_source_service->getSourceFile($media) : NULL;
+    $source_file = (is_object($media) && $media->bundle() <> 'remote_video') ? $media_source_service->getSourceFile($media) : NULL;
     if ($source_file) {
       $uri = $source_file->getFileUri();
     }


### PR DESCRIPTION
This addresses the issue: https://github.com/mjordan/islandora_riprap/issues/47

This issue only happens when the media type of "remote_video" is being used. In order to set this up, as admin navigate to "Add media type": http://localhost:8000/admin/structure/media/add -- NOTE: this media type will also need to have the two fields as are configured for all other islandora media types - these are "media_use" (a taxonomy entity reference) and "media_of" (entity reference).

The error was occurring when the riprap code attempted to call getSourceFile on an items' media when that item uses remote_video media type since there is not "file" underlying a remote_video media.

To reproduce the error, 
1. configure Islandora to have a media type of remote_video and add/edit a test item so that it includes a media that is using "Remote video"
2. observe the error on the item/{nid}/media page

To test the patched code:
1. follow steps above - but also pull in the code from this branch, clear the cache.
2. observe no error entry when viewing an item's media page that is using remote_video
