### PR TITLE
Allow use of remote video media

### DIFF
--- a/src/Plugin/views/field/RiprapResults.php
+++ b/src/Plugin/views/field/RiprapResults.php
@@ -61,7 +61,7 @@ class RiprapResults extends FieldPluginBase {
 
     // Look for events with an 'event_outcome' of 'fail'.
     $failed_events = 0;
-    if (count($events) > 0) {
+    if (!empty($events)) {
       foreach ($events as $event) {
         if ($event['event_outcome'] == 'fail') {
           $failed_events++;
@@ -83,7 +83,7 @@ class RiprapResults extends FieldPluginBase {
       }
     }
 
-    if (count($events) == 0) {
+    if (empty($events)) {
       $outcome = 'noevents';
       // Show mid and indicate that file is not in
       // Riprap (e.g., 'No Riprap events for $mid').

--- a/src/Riprap/Riprap.php
+++ b/src/Riprap/Riprap.php
@@ -190,7 +190,7 @@ class Riprap {
   public function getFedoraUrl($mid) {
     $media = Media::load($mid);
     if ($media->bundle() == 'remote_video') {
-      return False
+      return False;
     }
     $media_source_service = \Drupal::service('islandora.media_source_service');
     $source_file = $media_source_service->getSourceFile($media);

--- a/src/Riprap/Riprap.php
+++ b/src/Riprap/Riprap.php
@@ -189,6 +189,9 @@ class Riprap {
    */
   public function getFedoraUrl($mid) {
     $media = Media::load($mid);
+    if ($media->bundle() == 'remote_video') {
+      return False
+    }
     $media_source_service = \Drupal::service('islandora.media_source_service');
     $source_file = $media_source_service->getSourceFile($media);
     $uri = $source_file->getFileUri();

--- a/src/Riprap/Riprap.php
+++ b/src/Riprap/Riprap.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\islandora_riprap\Riprap;
 
+use GuzzleHttp\Exception\ConnectException;
 use Drupal\media\Entity\Media;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\Link;
@@ -62,22 +63,34 @@ class Riprap {
         return $body;
       }
       elseif ($code == 404) {
-        \Drupal::logger('islandora_riprap')->error('Riprap service not running or found at @endpoint', ['@endpoint' => $this->riprap_endpoint]);
+        \Drupal::logger('islandora_riprap')->error('Riprap service not running or found at @endpoint', [
+          '@endpoint' => $this->riprap_endpoint,
+        ]);
         // This is a special 'response' indicating that Riprap
         // was not found (or is not running) at its configured URL.
-        $status_message = t("Riprap not found or is not running at @endpoint", ['@endpoint' => $this->riprap_endpoint]);
-        return json_encode(['riprap_status' => 404, 'message' => $status_message]);
+        $status_message = t("Riprap not found or is not running at @endpoint", [
+          '@endpoint' => $this->riprap_endpoint,
+        ]);
+        return json_encode([
+          'riprap_status' => 404,
+          'message' => $status_message,
+        ]);
       }
       else {
-        \Drupal::messenger()->addMessage($this->t('Riprap does not have any fixity events for @resource_id.', ['@resource_id' => $resource_id]), 'warning');
+        \Drupal::messenger()->addMessage($this->t('Riprap does not have any fixity events for @resource_id.', [
+          '@resource_id' => $resource_id,
+        ]), 'warning');
         if ($this->show_warnings) {
           if ($resource_id !== 'Not in Fedora') {
-            \Drupal::logger('islandora_riprap')->error('HTTP response code returned by Riprap for request to @resource_id: @code', ['@code' => $code, '@resource_id' => $resource_id]);
+            \Drupal::logger('islandora_riprap')->error('HTTP response code returned by Riprap for request to @resource_id: @code', [
+              '@code' => $code,
+              '@resource_id' => $resource_id,
+            ]);
           }
         }
       }
     }
-    catch (RequestException $e) {
+    catch (ConnectException | RequestException $e) {
       \Drupal::logger('islandora_riprap')->error($e->getMessage());
       \Drupal::messenger()->addMessage($this->t('Sorry, there has been an error connecting to Riprap, please refer to the system log.'), 'error');
     }
@@ -97,7 +110,7 @@ class Riprap {
     foreach ($options as $option_name => $option_value) {
       $riprap_cmd[] = '--' . $option_name . '=' . $option_value;
     }
-    // @todo: limit is not being applied.
+    // @todo limit is not being applied.
     $process = new Process($riprap_cmd);
     $process->setWorkingDirectory($this->riprap_local_directory);
     $process->run();
@@ -155,10 +168,10 @@ class Riprap {
     else {
       $media_fields = [
         'field_media_file',
-	'field_media_document',
-	'field_media_image',
-	'field_media_audio_file',
-	'field_media_video_file',
+        'field_media_document',
+        'field_media_image',
+        'field_media_audio_file',
+        'field_media_video_file',
       ];
     }
     $media = Media::load($mid);
@@ -190,23 +203,22 @@ class Riprap {
   public function getFedoraUrl($mid) {
     $media = Media::load($mid);
     if ($media->bundle() == 'remote_video') {
-      return False;
+      return FALSE;
     }
     $media_source_service = \Drupal::service('islandora.media_source_service');
     $source_file = $media_source_service->getSourceFile($media);
     $uri = $source_file->getFileUri();
     $scheme = \Drupal::service('stream_wrapper_manager')->getScheme($uri);
-    $mapper = \Drupal::service('islandora.entity_mapper');
 
     $flysystem_config = Settings::get('flysystem');
     if (isset($flysystem_config[$scheme]) && $flysystem_config[$scheme]['driver'] == 'fedora') {
       $fedora_root = $flysystem_config['fedora']['config']['root'];
       $fedora_root = rtrim($fedora_root, '/');
       $parts = parse_url($uri);
-          $path = $parts['host'] . $parts['path'];
+      $path = $parts['host'] . $parts['path'];
     }
     else {
-      return false;
+      return FALSE;
     }
     $path = ltrim($path, '/');
     $fedora_uri = "$fedora_root/$path";
@@ -220,9 +232,9 @@ class Riprap {
    *
    * @param int $mid
    *   A Media ID.
-   *
    * @param bool $return_url
-   *   TRUE returns the file's http URL, FALSE returns the Drupal URI (e.g. public://).
+   *   TRUE returns the file's http URL,
+   *   FALSE returns the Drupal URI (e.g. public://).
    *
    * @return string
    *   The local Drupal URL of the file associated with the
@@ -236,10 +248,10 @@ class Riprap {
     else {
       $media_fields = [
         'field_media_file',
-	'field_media_document',
-	'field_media_image',
-	'field_media_audio_file',
-	'field_media_video_file',
+        'field_media_document',
+        'field_media_image',
+        'field_media_audio_file',
+        'field_media_video_file',
       ];
     }
     $media = Media::load($mid);
@@ -252,10 +264,10 @@ class Riprap {
         if ($return_url) {
           $url = file_create_url($media->$media_field->entity->getFileUri());
           return $url;
-	}
-	else {
-	  return $media->$media_field->entity->getFileUri();
-	}
+        }
+        else {
+          return $media->$media_field->entity->getFileUri();
+        }
       }
     }
   }
@@ -270,7 +282,12 @@ class Riprap {
     $chart_link = Link::createFromRoute('Failed fixity check events report',
       'islandora_riprap.events_report',
       [],
-      ['attributes' => ['target' => '_blank', 'title' => t('This report will open in a new tab')]]
+      [
+        'attributes' => [
+          'target' => '_blank',
+          'title' => t('This report will open in a new tab'),
+        ],
+      ]
     );
     return $chart_link->toString();
   }
@@ -282,7 +299,10 @@ class Riprap {
    *   Array of yyyy-mm month keys with number of failed events as values.
    */
   public function getFailedFixityEventsReportData() {
-    $event_data = $this->getEvents(['output_format' => 'json', 'outcome' => 'fail']);
+    $event_data = $this->getEvents([
+      'output_format' => 'json',
+      'outcome' => 'fail',
+    ]);
     $event_data_array = json_decode($event_data, TRUE);
     $months = [];
     foreach ($event_data_array as $event) {


### PR DESCRIPTION
Copied PR description from first attempt "Allow use of remote video media #48" -- since the branch name changed. 

This addresses the issue: #47

This issue only happens when the media type of "remote_video" is being used. In order to set this up, as admin navigate to "Add media type": http://localhost:8000/admin/structure/media/add -- NOTE: this media type will also need to have the two fields as are configured for all other islandora media types - these are "media_use" (a taxonomy entity reference) and "media_of" (entity reference).

The error was occurring when the riprap code attempted to call getSourceFile on an items' media when that item uses remote_video media type since there is not "file" underlying a remote_video media.

To reproduce the error,

configure Islandora to have a media type of remote_video and add/edit a test item so that it includes a media that is using "Remote video"
observe the error on the item/{nid}/media page
To test the patched code:

follow steps above - but also pull in the code from this branch, clear the cache.
observe no error entry when viewing an item's media page that is using remote_video